### PR TITLE
feat: improve code blocks with header, copy button, and styling

### DIFF
--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -5,6 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 import { DesignViewer } from "./design-viewer";
 import { TweetCard, type TweetCardProps } from "./tweet-card";
+import { Pre, CodeTab, CodeTabs, InlineCode } from "./mdx";
 
 const components = {
 	h1: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
@@ -138,24 +139,39 @@ const components = {
 			{...props}
 		/>
 	),
-	pre: ({ className, ...props }: React.HTMLAttributes<HTMLPreElement>) => (
-		<pre
-			className={cn(
-				"overflow-x-auto rounded-lg border bg-black py-2",
-				className,
-			)}
-			{...props}
-		/>
-	),
-	code: ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
-		<code
-			className={cn(
-				"relative rounded px-[0.3rem] font-mono text-sm",
-				className,
-			)}
-			{...props}
-		/>
-	),
+	pre: Pre,
+	code: ({
+		className,
+		children,
+		...props
+	}: React.HTMLAttributes<HTMLElement>) => {
+		// Check if this is inline code (not inside a pre element)
+		// rehype-pretty-code adds data-language to code blocks inside pre
+		const isInlineCode = !("data-language" in props);
+
+		if (isInlineCode) {
+			return (
+				<code
+					className={cn(
+						"relative rounded-md bg-white/10 px-1.5 py-0.5 font-mono text-sm text-[#e6edf3]",
+						className,
+					)}
+					{...props}
+				>
+					{children}
+				</code>
+			);
+		}
+
+		return (
+			<code className={cn("font-mono text-sm", className)} {...props}>
+				{children}
+			</code>
+		);
+	},
+	CodeTabs,
+	CodeTab,
+	InlineCode,
 	DesignViewer,
 	TweetCard: (props: TweetCardProps) => (
 		<div className="not-prose relative mx-auto max-w-xl py-6">

--- a/src/components/mdx/code-block.tsx
+++ b/src/components/mdx/code-block.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import {
+	Children,
+	isValidElement,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type ReactElement,
+	type ReactNode,
+} from "react";
+
+interface CopyButtonProps {
+	text: string;
+	className?: string;
+}
+
+function CopyButton({ text, className }: CopyButtonProps) {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch (err) {
+			console.error("Failed to copy:", err);
+		}
+	}, [text]);
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			className={cn(
+				"group/copy relative flex size-8 items-center justify-center rounded-md transition-all duration-200",
+				"text-muted-foreground hover:text-foreground hover:bg-white/10",
+				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+				className,
+			)}
+			aria-label={copied ? "Copied!" : "Copy code"}
+		>
+			<span className="sr-only">{copied ? "Copied!" : "Copy code"}</span>
+			{/* Copy icon */}
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				className={cn(
+					"absolute size-4 transition-all duration-200",
+					copied
+						? "scale-0 opacity-0"
+						: "scale-100 opacity-100 group-hover/copy:scale-110",
+				)}
+			>
+				<rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+				<path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+			</svg>
+			{/* Check icon */}
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				className={cn(
+					"absolute size-4 text-green-400 transition-all duration-200",
+					copied
+						? "scale-100 opacity-100"
+						: "scale-0 opacity-0",
+				)}
+			>
+				<polyline points="20 6 9 17 4 12" />
+			</svg>
+		</button>
+	);
+}
+
+interface CodeBlockHeaderProps {
+	language?: string;
+	title?: string;
+	showCopy?: boolean;
+	codeText: string;
+}
+
+function CodeBlockHeader({
+	language,
+	title,
+	showCopy = true,
+	codeText,
+}: CodeBlockHeaderProps) {
+	const displayName = title || language;
+
+	return (
+		<div className="flex items-center justify-between border-b border-white/10 bg-white/5 px-4 py-2">
+			<div className="flex items-center gap-2">
+				{displayName && (
+					<span className="font-mono text-xs text-muted-foreground">
+						{displayName}
+					</span>
+				)}
+			</div>
+			{showCopy && <CopyButton text={codeText} />}
+		</div>
+	);
+}
+
+interface CodeBlockProps {
+	children: ReactNode;
+	className?: string;
+	showLineNumbers?: boolean;
+	caption?: string;
+	"data-language"?: string;
+	"data-theme"?: string;
+	title?: string;
+}
+
+function extractTextFromChildren(children: ReactNode): string {
+	if (typeof children === "string") return children;
+	if (typeof children === "number") return String(children);
+	if (!children) return "";
+
+	if (Array.isArray(children)) {
+		return children.map(extractTextFromChildren).join("");
+	}
+
+	if (isValidElement(children)) {
+		const element = children as ReactElement<{ children?: ReactNode }>;
+		return extractTextFromChildren(element.props.children);
+	}
+
+	return "";
+}
+
+export function CodeBlock({
+	children,
+	className,
+	caption,
+	"data-language": language,
+	"data-theme": theme,
+	title,
+	...props
+}: CodeBlockProps) {
+	const preRef = useRef<HTMLPreElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [showStickyButton, setShowStickyButton] = useState(false);
+	const [isLongCode, setIsLongCode] = useState(false);
+
+	const codeText = extractTextFromChildren(children).trim();
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		// Check if code block is tall enough to warrant sticky button
+		const checkHeight = () => {
+			const height = container.offsetHeight;
+			setIsLongCode(height > 300);
+		};
+
+		checkHeight();
+		window.addEventListener("resize", checkHeight);
+		return () => window.removeEventListener("resize", checkHeight);
+	}, []);
+
+	useEffect(() => {
+		if (!isLongCode) return;
+
+		const container = containerRef.current;
+		if (!container) return;
+
+		const handleScroll = () => {
+			const rect = container.getBoundingClientRect();
+			const headerHeight = 48; // Height of header
+			// Show sticky button when header is scrolled past
+			setShowStickyButton(rect.top < -headerHeight && rect.bottom > 100);
+		};
+
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, [isLongCode]);
+
+	return (
+		<figure className="group/codeblock my-6">
+			<div
+				ref={containerRef}
+				className={cn(
+					"relative overflow-hidden rounded-xl border border-white/10 bg-[#22272e]",
+					className,
+				)}
+			>
+				<CodeBlockHeader
+					language={language}
+					title={title}
+					codeText={codeText}
+				/>
+				<div className="relative">
+					<pre
+						ref={preRef}
+						className="overflow-x-auto py-4 text-sm leading-relaxed"
+						data-language={language}
+						data-theme={theme}
+						{...props}
+					>
+						{children}
+					</pre>
+					{/* Sticky copy button for long code blocks */}
+					{isLongCode && (
+						<div
+							className={cn(
+								"fixed right-8 top-20 z-50 transition-all duration-300",
+								showStickyButton
+									? "translate-y-0 opacity-100"
+									: "-translate-y-4 pointer-events-none opacity-0",
+							)}
+						>
+							<CopyButton
+								text={codeText}
+								className="size-10 rounded-lg border border-white/10 bg-[#22272e]/95 shadow-lg backdrop-blur-sm"
+							/>
+						</div>
+					)}
+				</div>
+			</div>
+			{caption && (
+				<figcaption className="mt-2 text-center text-sm text-muted-foreground">
+					{caption}
+				</figcaption>
+			)}
+		</figure>
+	);
+}
+
+// Pre component that wraps CodeBlock for MDX
+interface PreProps extends React.HTMLAttributes<HTMLPreElement> {
+	children?: ReactNode;
+	"data-language"?: string;
+	"data-theme"?: string;
+	title?: string;
+	caption?: string;
+	raw?: string;
+}
+
+export function Pre({
+	children,
+	className,
+	"data-language": language,
+	"data-theme": theme,
+	title,
+	caption,
+	...props
+}: PreProps) {
+	return (
+		<CodeBlock
+			data-language={language}
+			data-theme={theme}
+			title={title}
+			caption={caption}
+			className={className}
+		>
+			{children}
+		</CodeBlock>
+	);
+}

--- a/src/components/mdx/code-tabs.tsx
+++ b/src/components/mdx/code-tabs.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import {
+	Children,
+	isValidElement,
+	useState,
+	type ReactElement,
+	type ReactNode,
+} from "react";
+
+interface CodeTabProps {
+	label: string;
+	children: ReactNode;
+}
+
+export function CodeTab({ children }: CodeTabProps) {
+	return <>{children}</>;
+}
+
+interface CodeTabsProps {
+	children: ReactNode;
+	defaultTab?: number;
+	className?: string;
+}
+
+function extractTextFromChildren(children: ReactNode): string {
+	if (typeof children === "string") return children;
+	if (typeof children === "number") return String(children);
+	if (!children) return "";
+
+	if (Array.isArray(children)) {
+		return children.map(extractTextFromChildren).join("");
+	}
+
+	if (isValidElement(children)) {
+		const element = children as ReactElement<{ children?: ReactNode }>;
+		return extractTextFromChildren(element.props.children);
+	}
+
+	return "";
+}
+
+function CopyButton({
+	text,
+	className,
+}: { text: string; className?: string }) {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch (err) {
+			console.error("Failed to copy:", err);
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			className={cn(
+				"group/copy relative flex size-8 items-center justify-center rounded-md transition-all duration-200",
+				"text-muted-foreground hover:text-foreground hover:bg-white/10",
+				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+				className,
+			)}
+			aria-label={copied ? "Copied!" : "Copy code"}
+		>
+			<span className="sr-only">{copied ? "Copied!" : "Copy code"}</span>
+			{/* Copy icon */}
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				className={cn(
+					"absolute size-4 transition-all duration-200",
+					copied
+						? "scale-0 opacity-0"
+						: "scale-100 opacity-100 group-hover/copy:scale-110",
+				)}
+			>
+				<rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+				<path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+			</svg>
+			{/* Check icon */}
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				className={cn(
+					"absolute size-4 text-green-400 transition-all duration-200",
+					copied ? "scale-100 opacity-100" : "scale-0 opacity-0",
+				)}
+			>
+				<polyline points="20 6 9 17 4 12" />
+			</svg>
+		</button>
+	);
+}
+
+export function CodeTabs({
+	children,
+	defaultTab = 0,
+	className,
+}: CodeTabsProps) {
+	const [activeTab, setActiveTab] = useState(defaultTab);
+
+	const tabs = Children.toArray(children).filter(
+		(child): child is ReactElement<CodeTabProps> =>
+			isValidElement(child) && child.type === CodeTab,
+	);
+
+	if (tabs.length === 0) {
+		return null;
+	}
+
+	const activeContent = tabs[activeTab]?.props.children;
+	const activeCode = extractTextFromChildren(activeContent).trim();
+
+	return (
+		<figure className="group/codeblock my-6">
+			<div
+				className={cn(
+					"overflow-hidden rounded-xl border border-white/10 bg-[#22272e]",
+					className,
+				)}
+			>
+				{/* Tab header */}
+				<div className="flex items-center justify-between border-b border-white/10 bg-white/5">
+					<div className="flex">
+						{tabs.map((tab, index) => (
+							<button
+								key={tab.props.label}
+								type="button"
+								onClick={() => setActiveTab(index)}
+								className={cn(
+									"relative px-4 py-2 font-mono text-xs transition-colors",
+									activeTab === index
+										? "text-foreground"
+										: "text-muted-foreground hover:text-foreground/80",
+								)}
+							>
+								{tab.props.label}
+								{activeTab === index && (
+									<span className="absolute inset-x-0 -bottom-px h-0.5 bg-primary" />
+								)}
+							</button>
+						))}
+					</div>
+					<CopyButton text={activeCode} className="mr-2" />
+				</div>
+
+				{/* Tab content */}
+				<div className="relative">
+					{tabs.map((tab, index) => (
+						<div
+							key={tab.props.label}
+							className={cn(
+								"transition-opacity duration-200",
+								activeTab === index
+									? "opacity-100"
+									: "hidden opacity-0",
+							)}
+						>
+							{tab.props.children}
+						</div>
+					))}
+				</div>
+			</div>
+		</figure>
+	);
+}

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -1,0 +1,3 @@
+export { CodeBlock, Pre } from "./code-block";
+export { CodeTab, CodeTabs } from "./code-tabs";
+export { InlineCode } from "./inline-code";

--- a/src/components/mdx/inline-code.tsx
+++ b/src/components/mdx/inline-code.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useCallback, useState, type ReactNode } from "react";
+
+type ColorVariant =
+	| "default"
+	| "primary"
+	| "success"
+	| "warning"
+	| "error"
+	| "info";
+
+interface InlineCodeProps {
+	children: ReactNode;
+	className?: string;
+	color?: ColorVariant;
+	copyable?: boolean;
+}
+
+const colorVariants: Record<ColorVariant, string> = {
+	default: "bg-white/10 text-[#e6edf3]",
+	primary: "bg-blue-500/20 text-blue-300",
+	success: "bg-green-500/20 text-green-300",
+	warning: "bg-yellow-500/20 text-yellow-300",
+	error: "bg-red-500/20 text-red-300",
+	info: "bg-cyan-500/20 text-cyan-300",
+};
+
+function extractText(children: ReactNode): string {
+	if (typeof children === "string") return children;
+	if (typeof children === "number") return String(children);
+	if (!children) return "";
+
+	if (Array.isArray(children)) {
+		return children.map(extractText).join("");
+	}
+
+	return "";
+}
+
+export function InlineCode({
+	children,
+	className,
+	color = "default",
+	copyable = true,
+}: InlineCodeProps) {
+	const [copied, setCopied] = useState(false);
+	const [showTooltip, setShowTooltip] = useState(false);
+
+	const text = extractText(children);
+
+	const handleCopy = useCallback(async () => {
+		if (!copyable) return;
+
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch (err) {
+			console.error("Failed to copy:", err);
+		}
+	}, [copyable, text]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (copyable && (e.key === "Enter" || e.key === " ")) {
+				e.preventDefault();
+				handleCopy();
+			}
+		},
+		[copyable, handleCopy],
+	);
+
+	return (
+		<span className="relative inline-block">
+			<code
+				onClick={handleCopy}
+				onKeyDown={handleKeyDown}
+				onMouseEnter={() => copyable && setShowTooltip(true)}
+				onMouseLeave={() => setShowTooltip(false)}
+				role={copyable ? "button" : undefined}
+				tabIndex={copyable ? 0 : undefined}
+				className={cn(
+					"relative rounded-md px-1.5 py-0.5 font-mono text-sm transition-all duration-200",
+					colorVariants[color],
+					copyable && [
+						"cursor-pointer",
+						"hover:ring-2 hover:ring-white/20",
+						"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+						"active:scale-95",
+					],
+					className,
+				)}
+			>
+				{children}
+			</code>
+			{/* Tooltip */}
+			{copyable && (
+				<span
+					className={cn(
+						"pointer-events-none absolute -top-8 left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded-md bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md transition-all duration-200",
+						showTooltip || copied
+							? "translate-y-0 opacity-100"
+							: "translate-y-1 opacity-0",
+					)}
+				>
+					{copied ? "Copied!" : "Click to copy"}
+				</span>
+			)}
+		</span>
+	);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -303,3 +303,72 @@ code[data-line-numbers-max-digits="2"]>[data-line]::before {
 code[data-line-numbers-max-digits="3"]>[data-line]::before {
     width: 3rem;
 }
+
+/* Code block styling */
+[data-rehype-pretty-code-figure] pre {
+    @apply border-0 bg-transparent py-0;
+}
+
+[data-rehype-pretty-code-figure] code {
+    @apply grid text-sm;
+    counter-reset: line;
+}
+
+[data-rehype-pretty-code-figure] [data-line] {
+    @apply border-l-2 border-transparent px-4 py-0.5;
+}
+
+/* Line highlighting */
+[data-rehype-pretty-code-figure] .line--highlighted {
+    @apply border-l-blue-400 bg-blue-500/10;
+}
+
+/* Word highlighting */
+[data-rehype-pretty-code-figure] .word--highlighted {
+    @apply rounded-sm bg-blue-500/25 px-1 py-0.5;
+}
+
+/* Diff notation styling */
+[data-rehype-pretty-code-figure] [data-highlighted-line-id="add"] {
+    @apply border-l-green-400 bg-green-500/15;
+}
+
+[data-rehype-pretty-code-figure] [data-highlighted-line-id="remove"] {
+    @apply border-l-red-400 bg-red-500/15;
+}
+
+[data-rehype-pretty-code-figure] [data-diff="+"] {
+    @apply border-l-green-400 bg-green-500/15;
+}
+
+[data-rehype-pretty-code-figure] [data-diff="-"] {
+    @apply border-l-red-400 bg-red-500/15;
+}
+
+/* Focus notation - dim unfocused lines */
+[data-rehype-pretty-code-figure]:has([data-highlighted-line-id="focus"]) [data-line]:not([data-highlighted-line-id="focus"]) {
+    @apply opacity-50 transition-opacity;
+}
+
+[data-rehype-pretty-code-figure]:has([data-highlighted-line-id="focus"]):hover [data-line] {
+    @apply opacity-100;
+}
+
+/* Inline code within prose */
+:not(pre) > code {
+    @apply rounded-md bg-white/10 px-1.5 py-0.5 font-mono text-sm text-[#e6edf3];
+}
+
+/* Code title styling */
+[data-rehype-pretty-code-title] {
+    @apply rounded-t-xl border border-b-0 border-white/10 bg-white/5 px-4 py-2 font-mono text-xs text-muted-foreground;
+}
+
+[data-rehype-pretty-code-title] + pre {
+    @apply rounded-t-none;
+}
+
+/* Code caption styling */
+[data-rehype-pretty-code-caption] {
+    @apply mt-2 text-center text-sm text-muted-foreground;
+}


### PR DESCRIPTION
- Add CodeBlock component with language header and animated copy button
- Add CodeTabs component for multi-tab code blocks
- Add InlineCode component with click-to-copy and color variants
- Add sticky copy button for long code blocks (ChatGPT-style)
- Add CSS styling for line/word highlighting, diff notation, and focus
- Integrate new components with MDX renderer